### PR TITLE
A quick demo for scala  2.11 and play 2.5

### DIFF
--- a/scalaslick/README.md
+++ b/scalaslick/README.md
@@ -1,0 +1,14 @@
+# scalaSlick
+
+
+## Start it
+
+```
+sloppy start -var=URI:mydomain.sloppy.zone -var=ROOTPW:root-password-for-mysql -var=MYSQLUSER:regular-mysql-user -var=MYSQLPASSWORD:regular-mysqluser-password scalaslick.json
+
+Example:
+   
+sloppy start -var=URI:claydonkey-scala.sloppy.zone -var=ROOTPW:myrootpwd -var=MYSQLUSER:ownme -var=MYSQLPASSWORD:s3cure scalaslick.json
+```
+
+During the setup process choose MySQL as Database and fill in username and password you defined for the mysql container. The hostname is mysql.backend.scalaslick.YOUR-SLOPPY-USERNAME

--- a/scalaslick/README.md
+++ b/scalaslick/README.md
@@ -12,3 +12,36 @@ sloppy start -var=URI:claydonkey-scala.sloppy.zone -var=ROOTPW:myrootpwd -var=MY
 ```
 
 During the setup process choose MySQL as Database and fill in username and password you defined for the mysql container. The hostname is mysql.backend.scalaslick.YOUR-SLOPPY-USERNAME
+
+Demos
+play-slick 1.1.0
+play-slick-evolutions 1.1.0
+using mysql
+
+Git repository
+https://github.com/claydonkey/sloppy-slick
+Docker Repository
+https://hub.docker.com/r/claydonkey/sloppy-slick/
+
+## For Repository
+
+##compile
+```
+sbt compile
+```
+##stage
+```
+sbt docker:stage
+```
+##build (locally) 
+```
+docker build -t claydonkey/sloppy-slick:local .
+```
+##run (from hub.docker)
+```
+docker-compose up
+```
+##run (locally)
+```
+docker run --env SLICK_DB_IP_ADDRESS={YOURIP} SLICK_DB_PORT=3306 SLICK_DB_NAME={YOURDBNAME} SLICK_DB_USER={YOURDBUSER} --name sloppy_slick -dp 9000:9000 claydonkey/sloppy-slick:local
+```

--- a/scalaslick/scalaslick.json
+++ b/scalaslick/scalaslick.json
@@ -1,0 +1,55 @@
+{
+    "project": "scalaslick",
+    "services": [
+	{
+	    "id": "frontend",
+	    "apps": [
+		{
+		    "domain": {
+			"uri": "$URI",
+			"type": "HTTP"
+		    },
+		    "mem": 512,
+		    "image": "claydonkey/sloppy-slick:latest",
+		    "instances": 1,
+		    "id": "play",
+		    "health_checks": [],
+		    "volumes": [],
+		    "env": {
+			"SLICK_DB_IP_ADDRESS": "mysql.backend.scalaslick",
+			"SLICK_DB_PORT": "3306",
+			"SLICK_DB_NAME": "scalaslick",
+			"SLICK_DB_USER": "$MYSQLUSER",
+			"SLICK_DB_PASSWORD": "$MYSQLPASSWORD"
+		    },
+		    "port_mappings": [
+			{
+			    "container_port": 9000,
+			    "protocol": "tcp"
+			}
+		    ],
+		    "dependencies": [
+			"../../backend/mysql"
+		    ]
+		}
+	    ]
+	},
+	{
+	    "id": "backend",
+	    "apps": [
+		{
+		    "id": "mysql",
+		    "env": {
+			"MYSQL_ROOT_PASSWORD": "$ROOTPW",
+			"MYSQL_USER": "$MYSQLUSER",
+			"MYSQL_PASSWORD": "$MYSQLPASSWORD",
+			"MYSQL_DATABASE": "scalaslick"
+		    },
+		    "instances": 1,
+		    "mem": 512,
+		    "image": "mysql"
+		}
+	    ]
+	}
+    ]
+}


### PR DESCRIPTION
Demos
play-slick 1.1.0
play-slick-evolutions 1.1.0
using mysql 

Git repository
[https://github.com/claydonkey/sloppy-slick](https://github.com/claydonkey/sloppy-slick)
Docker Repository
[https://hub.docker.com/r/claydonkey/sloppy-slick/](https://hub.docker.com/r/claydonkey/sloppy-slick/)

**compile**
sbt compile
**stage** 
sbt docker:stage
**build (locally)** 
docker build -t claydonkey/sloppy-slick:local .
**run** (from hub.docker)
docker-compose up
**run** (locally)
docker run  --env SLICK_DB_IP_ADDRESS={YOURIP} SLICK_DB_PORT=3306 SLICK_DB_NAME={YOURDBNAME} SLICK_DB_USER={YOURDBUSER}  --name sloppy_slick -dp 9000:9000 claydonkey/sloppy-slick:local
