### PR TITLE
Remove invalid env vars from JSON, add volumes, simplify and fix README

### DIFF
--- a/lychee/README.md
+++ b/lychee/README.md
@@ -5,11 +5,7 @@ https://lychee.electerious.com/
 ## Start it
 
 ```
-sloppy start -var=URI:mydomain.sloppy.zone -var=DBUSER:mysqlusernamer -var=DBPASS:mysqluserpassword -var=DBROOT:rootpassword -var=DBDATABASE:lychee lychee.yml
-   
-Example:
-   
-sloppy start -var=URI:pix.sloppy.zone -var=DBUSER:mysqluser -var=DBPASS:secret -var=DBROOT:moresecret -var=DBDATABASE:lychee lychee.yml
+sloppy start -var=URI:mydomain.sloppy.zone -var=DBUSER:mysqluser -var=DBPASS:secret -var=DBROOT:moresecret lychee.yml
 ```
 
-On the setup page enter mysql.backend.lychee.YOURUSERNAME and "lychee" as the 
+On the setup page enter mysql.backend.lychee.YOURUSERID (you can find your userid on the [My Account page](https://admin.sloppy.io/account/profile)) and "lychee" as the database.

--- a/lychee/lychee.json
+++ b/lychee/lychee.json
@@ -7,8 +7,7 @@
                 {
                     "id":"apache",
                     "domain":{
-                        "uri":"$URI",
-                        "type":"HTTP"
+                        "uri":"$URI"
                     },
                     "instances":1,
                     "mem":512,
@@ -18,13 +17,13 @@
                             "container_port":80
                         }
                     ],
-                    "env":{
-                        "WORDPRESS_DB_HOST":"mysql.backend.lychee.$USERNAME",
-                        "WORDPRESS_DB_USER":"$DBUSER",
-                        "WORDPRESS_DB_PASSWORD":"$DBPASS"
-                    },
                     "dependencies":[
                         "../backend/mysql"
+                    ],
+                    "volumes": [
+                      {
+                        "container_path": "/uploads"
+                      }
                     ]
                 }
             ]
@@ -41,8 +40,13 @@
                         "MYSQL_ROOT_PASSWORD":"$DBROOT",
                         "MYSQL_USER":"$DBUSER",
                         "MYSQL_PASSWORD":"$DBPASS",
-                        "MYSQL_DATABASE":"wordpress"
-                    }
+                        "MYSQL_DATABASE":"lychee"
+                    },
+                    "volumes": [
+                      {
+                        "container_path": "/var/lib/mysql"
+                      }
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
The JSON file for lychee had a bunch of issues: Some irrelevant WORDPRESS env vars, missing volumes, wrong DB name. 

The README had pretty much the same example twice, so I removed one of them. Also dropped the DBDATABASE var there, since it doesn't exist.
