### PR TITLE
Rename vars to be consistent with other quickstarters, needed for generators

### DIFF
--- a/owncloud/README.md
+++ b/owncloud/README.md
@@ -4,11 +4,11 @@
 ## Start it
 
 ```
-sloppy start -var=URI:mydomain.sloppy.zone -var=ROOTPW:root-password-for-mysql -var=MYSQLUSER:regular-mysql-user -var=MYSQLPASSWORD:regular-mysqluser-password owncloud.json
+sloppy start -var=URI:mydomain.sloppy.zone -var=DBROOT:root-password-for-mysql -var=DBUSER:regular-mysql-user -var=DBPASS:regular-mysqluser-password owncloud.json
 
 Example:
-   
-sloppy start -var=URI:ownklaut.sloppy.zone -var=ROOTPW:myrootpwd -var=MYSQLUSER:ownme -var=MYSQLPASSWORD:s3cure owncloud.json
+
+sloppy start -var=URI:ownklaut.sloppy.zone -var=DBROOT:myrootpwd -var=DBUSER:ownme -var=DBPASS:s3cure owncloud.json
 ```
 
 During the setup process choose MySQL as Database and fill in username and password you defined for the mysql container. The hostname is mysql.backend.owncloud.YOUR-SLOPPY-USERNAME

--- a/owncloud/owncloud.json
+++ b/owncloud/owncloud.json
@@ -39,9 +39,9 @@
                     "mem":512,
                     "image":"mysql",
                     "env":{
-                        "MYSQL_ROOT_PASSWORD":"$ROOTPW",
-                        "MYSQL_USER":"$MYSQLUSER",
-                        "MYSQL_PASSWORD":"$MYSQLPASSWORD",
+                        "MYSQL_ROOT_PASSWORD":"$DBROOT",
+                        "MYSQL_USER":"$DBUSER",
+                        "MYSQL_PASSWORD":"$DBPASS",
                         "MYSQL_DATABASE":"owncloud"
                     },
                     "volumes":[

--- a/owncloud/owncloud.yml
+++ b/owncloud/owncloud.yml
@@ -19,9 +19,9 @@ services:
       instances: 1
       mem: 512
       env:
-        - MYSQL_ROOT_PASSWORD: "$ROOTPW"
-        - MYSQL_USER: "$MYSQLUSER"
-        - MYSQL_PASSWORD: "$MYSQLPASSWORD"
+        - MYSQL_ROOT_PASSWORD: "$DBROOT"
+        - MYSQL_USER: "$DBUSER"
+        - MYSQL_PASSWORD: "$DBPASS"
         - MYSQL_DATABASE: "owncloud"
       volumes:
         - path: "/var/lib/mysql"

--- a/scalaslick/README.md
+++ b/scalaslick/README.md
@@ -4,11 +4,11 @@
 ## Start it
 
 ```
-sloppy start -var=URI:mydomain.sloppy.zone -var=ROOTPW:root-password-for-mysql -var=MYSQLUSER:regular-mysql-user -var=MYSQLPASSWORD:regular-mysqluser-password scalaslick.json
+sloppy start -var=URI:mydomain.sloppy.zone -var=DBROOT:root-password-for-mysql -var=DBUSER:regular-mysql-user -var=DBPASS:regular-mysqluser-password scalaslick.json
 
 Example:
-   
-sloppy start -var=URI:claydonkey-scala.sloppy.zone -var=ROOTPW:myrootpwd -var=MYSQLUSER:ownme -var=MYSQLPASSWORD:s3cure scalaslick.json
+
+sloppy start -var=URI:claydonkey-scala.sloppy.zone -var=DBROOT:myrootpwd -var=DBUSER:ownme -var=DBPASS:s3cure scalaslick.json
 ```
 
 During the setup process choose MySQL as Database and fill in username and password you defined for the mysql container. The hostname is mysql.backend.scalaslick.YOUR-SLOPPY-USERNAME
@@ -33,7 +33,7 @@ sbt compile
 ```
 sbt docker:stage
 ```
-##build (locally) 
+##build (locally)
 ```
 docker build -t claydonkey/sloppy-slick:local .
 ```

--- a/scalaslick/scalaslick.json
+++ b/scalaslick/scalaslick.json
@@ -19,8 +19,8 @@
 			"SLICK_DB_IP_ADDRESS": "mysql.backend.scalaslick",
 			"SLICK_DB_PORT": "3306",
 			"SLICK_DB_NAME": "scalaslick",
-			"SLICK_DB_USER": "$MYSQLUSER",
-			"SLICK_DB_PASSWORD": "$MYSQLPASSWORD"
+			"SLICK_DB_USER": "$DBUSER",
+			"SLICK_DB_PASSWORD": "$DBPASS"
 		    },
 		    "port_mappings": [
 			{
@@ -40,9 +40,9 @@
 		{
 		    "id": "mysql",
 		    "env": {
-			"MYSQL_ROOT_PASSWORD": "$ROOTPW",
-			"MYSQL_USER": "$MYSQLUSER",
-			"MYSQL_PASSWORD": "$MYSQLPASSWORD",
+			"MYSQL_ROOT_PASSWORD": "$DBROOT",
+			"MYSQL_USER": "$DBUSER",
+			"MYSQL_PASSWORD": "$DBPASS",
 			"MYSQL_DATABASE": "scalaslick"
 		    },
 		    "instances": 1,


### PR DESCRIPTION
As long as all quickstarters use the same DBROOT, DBUSER and DBPASS variables, we can reasonably generate values for each.
