### PR TITLE
Use https for any (root) URLs

### DIFF
--- a/gitlab/gitlab.json
+++ b/gitlab/gitlab.json
@@ -29,7 +29,7 @@
                         }
                     ],
                     "env":{
-                        "GITLAB_OMNIBUS_CONFIG":"external_url 'http://$URI';"
+                        "GITLAB_OMNIBUS_CONFIG":"external_url 'https://$URI';"
                     },
                     "health_checks":[
                         {

--- a/gitlab/gitlab.yml
+++ b/gitlab/gitlab.yml
@@ -13,7 +13,7 @@ services:
         - container_path: "/var/opt/gitlab"
         - container_path: "/var/log/gitlab"
       env:
-        - GITLAB_OMNIBUS_CONFIG: "external_url 'http://$URI';"
+        - GITLAB_OMNIBUS_CONFIG: "external_url 'https://$URI';"
       healthchecks:
         -
           timeout_seconds: 10

--- a/gogs/README.md
+++ b/gogs/README.md
@@ -6,10 +6,10 @@ Gogs - Go Git Service https://gogs.io/
 
 ```
 sloppy start -var=URI:mydomain.sloppy.zone gogs.json
-   
+
 Example:
-   
+
 sloppy start -var=URI:mygogs.sloppy.zone gogs.json
 ```
 
-On the setup page choose sqlite as database and change Application-URL to the .sloppy.zone subdomain (for example http://mygogs.sloppy.zone) you choosed. As sloppy.io does not support TCP ports for exposing in the public version you can not use SSH for git commands.
+On the setup page choose sqlite as database and change Application-URL to the .sloppy.zone subdomain (for example https://mygogs.sloppy.zone) you choosed. As sloppy.io does not support TCP ports for exposing in the public version you can not use SSH for git commands.

--- a/rocketchat/rocketchat.json
+++ b/rocketchat/rocketchat.json
@@ -25,7 +25,7 @@
           ],
           "env": {
             "MONGO_URL": "mongodb://mongodb.backend.rocketchat/rocketchat",
-            "ROOT_URL": "http://$URI"
+            "ROOT_URL": "https://$URI"
           },
           "dependencies": [
             "../backend/mongodb"

--- a/rocketchat/rocketchat.yml
+++ b/rocketchat/rocketchat.yml
@@ -13,7 +13,7 @@ services:
       port: 3000
       env:
         - MONGO_URL: "mongodb://mongodb.backend.rocketchat/rocketchat"
-        - ROOT_URL: "http://$URI"
+        - ROOT_URL: "https://$URI"
       dependencies:
         - "../backend/mongodb"
   backend:

--- a/wekan/wekan.json
+++ b/wekan/wekan.json
@@ -19,7 +19,7 @@
           ],
           "env": {
             "MONGO_URL": "mongodb://mongodb.backend.wekan/wekan",
-            "ROOT_URL": "http://$URI"
+            "ROOT_URL": "https://$URI"
           },
           "dependencies": [
             "../backend/mongodb"


### PR DESCRIPTION
Noticed while testing the rocketchat quickstarter, which is unhappy about the ROOT_URL not matching the actual https URL.