### PR TITLE
fix(letschat): add missing volumes

### DIFF
--- a/letschat/letschat.json
+++ b/letschat/letschat.json
@@ -22,6 +22,16 @@
           },
           "dependencies": [
             "../backend/mongodb"
+          ],
+          "volumes": [
+            {
+              "container_path": "/usr/src/app/config",
+              "size": "8GB"
+            },
+            {
+              "container_path": "/usr/src/app/uploads",
+              "size": "8GB"
+            }
           ]
         }
       ]

--- a/letschat/letschat.yml
+++ b/letschat/letschat.yml
@@ -12,6 +12,9 @@ services:
         - LCB_DATABASE_URI: "mongodb://mongodb.backend.letschat/letschat"
       dependencies:
         - "../backend/mongodb"
+      volumes:
+        - path: "/usr/src/app/config"
+        - path: "/usr/src/app/uploads"
   backend:
     mongodb:
       image: "mongo"


### PR DESCRIPTION
Tested both deployments. Without these deployment fails:

error: Validation failed App "node" needs the following volumes: /usr/src/app/config, /usr/src/app/uploads; Please add those volumes